### PR TITLE
Add overflow to code blocks

### DIFF
--- a/assets/css/rocinante.scss
+++ b/assets/css/rocinante.scss
@@ -103,6 +103,7 @@ pre code {
   margin: 1em 0;
   padding: 0.75em 1em;
   color: inherit;
+  overflow: auto;
 }
 
 img, video {


### PR DESCRIPTION
This will let them scale on mobile devices a little bit better. Currently code blocks will render up to the width of the screen and code that's longer will just overflow.
